### PR TITLE
feat: add quizzes model, repository, and controller

### DIFF
--- a/elms-backend/src/main/java/com/elms/backend/controller/QuizController.java
+++ b/elms-backend/src/main/java/com/elms/backend/controller/QuizController.java
@@ -1,0 +1,21 @@
+package com.elms.backend.controller;
+
+import com.elms.backend.model.Quiz;
+import com.elms.backend.repository.QuizRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@CrossOrigin(origins = "http://localhost:3000")
+public class QuizController {
+
+    @Autowired
+    private QuizRepository quizRepository;
+
+    @GetMapping("/courses/{courseId}/quizzes")
+    public List<Quiz> getQuizzesForCourse(@PathVariable Long courseId) {
+        return quizRepository.findByCourseId(courseId);
+    }
+}

--- a/elms-backend/src/main/java/com/elms/backend/model/Quiz.java
+++ b/elms-backend/src/main/java/com/elms/backend/model/Quiz.java
@@ -1,0 +1,21 @@
+package com.elms.backend.model;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Entity
+@Table(name = "quizzes")
+@Data
+public class Quiz {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @ManyToOne
+    @JoinColumn(name = "course_id")
+    @JsonBackReference
+    private Course course;
+}

--- a/elms-backend/src/main/java/com/elms/backend/model/Quiz.java
+++ b/elms-backend/src/main/java/com/elms/backend/model/Quiz.java
@@ -3,6 +3,7 @@ package com.elms.backend.model;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.Data;
+import com.elms.backend.model.Course;
 
 @Entity
 @Table(name = "quizzes")

--- a/elms-backend/src/main/java/com/elms/backend/repository/QuizRepository.java
+++ b/elms-backend/src/main/java/com/elms/backend/repository/QuizRepository.java
@@ -1,0 +1,9 @@
+package com.elms.backend.repository;
+
+import com.elms.backend.model.Quiz;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface QuizRepository extends JpaRepository<Quiz, Long> {
+    List<Quiz> findByCourseId(Long courseId);
+}


### PR DESCRIPTION
### Overview
This PR adds support for quizzes in the ELMS backend.

### Changes Introduced
- Added `Quiz` entity in `model` package
- Added `QuizRepository` in `repository` package
- Added `QuizController` in `controller` package with endpoint to fetch quizzes by course

### API Endpoint
- `GET /api/courses/{courseId}/quizzes`  
  → Returns all quizzes for a specific course

### Notes
- `Course` model will need a `List<Quiz>` relationship (to be coordinated with the team lead).
- Currently tested locally with dummy data.

### Next Steps
- Integration with frontend
- Add unit tests
- Verify relationship with `Course` once updated
